### PR TITLE
add support for 'fields' parameter in 'find' method

### DIFF
--- a/SwiftMongoDB/MongoCollection.swift
+++ b/SwiftMongoDB/MongoCollection.swift
@@ -55,24 +55,39 @@ public class MongoCollection {
         try error.throwIfError()
     }
     
-    public func find(query: DocumentData = DocumentData(), flags: QueryFlags = QueryFlags.None, skip: Int = 0, limit: Int = 0, batchSize: Int = 0) throws -> [MongoDocument] {
+    public func find(query: DocumentData = DocumentData(), fields: DocumentData? = nil, flags: QueryFlags = QueryFlags.None, skip: Int = 0, limit: Int = 0, batchSize: Int = 0) throws -> [MongoDocument] {
 
         var query = try MongoBSON(data: query).bson
-
         // standard options - should be customizable later on
-        let cursor = MongoCursor(
-            collection: self,
-            operation: .Find,
-            query: &query,
-            options: (
-                queryFlags: flags.rawFlag,
-                skip: skip,
-                limit: limit,
-                batchSize: batchSize
-            )
+        let options = (
+            queryFlags: flags.rawFlag,
+            skip: skip,
+            limit: limit,
+            batchSize: batchSize
         )
-
-        let documents = try cursor.getDocuments()
+        
+        var cursor: MongoCursor
+        let documents: [MongoDocument]
+        if fields == nil {
+            cursor = MongoCursor(
+                collection: self,
+                operation: .Find,
+                query: &query,
+                fields: nil,
+                options: options
+            )
+            documents = try cursor.getDocuments()
+        } else {
+            var fields = try MongoBSON(data: fields!).bson
+            cursor = MongoCursor(
+                collection: self,
+                operation: .Find,
+                query: &query,
+                fields: &fields,
+                options: options
+            )
+            documents = try cursor.getDocuments()
+        }
 
         if cursor.lastError.isError {
             throw cursor.lastError
@@ -81,9 +96,9 @@ public class MongoCollection {
         return documents
     }
     
-    public func findOne(query: DocumentData = DocumentData(), flags: QueryFlags = QueryFlags.None, skip: Int = 0, batchSize: Int = 0) throws -> MongoDocument? {
+    public func findOne(query: DocumentData = DocumentData(), fields: DocumentData? = nil, flags: QueryFlags = QueryFlags.None, skip: Int = 0, batchSize: Int = 0) throws -> MongoDocument? {
 
-        let doc = try find(query, flags: flags, skip: skip, limit: 1, batchSize: batchSize)
+        let doc = try find(query, fields: fields, flags: flags, skip: skip, limit: 1, batchSize: batchSize)
 
         if doc.count == 0 {
             return nil

--- a/SwiftMongoDB/MongoCollection.swift
+++ b/SwiftMongoDB/MongoCollection.swift
@@ -66,7 +66,7 @@ public class MongoCollection {
             batchSize: batchSize
         )
         
-        var cursor: MongoCursor
+        let cursor: MongoCursor
         let documents: [MongoDocument]
         if fields == nil {
             cursor = MongoCursor(

--- a/SwiftMongoDB/MongoCursor.swift
+++ b/SwiftMongoDB/MongoCursor.swift
@@ -23,7 +23,7 @@ public class MongoCursor {
     }
     
     // this is way too ugly
-    init(collection: MongoCollection, operation: MongoCursorOperation, query: _bson_ptr_mutable, options: MongoCursorOptions) {
+    init(collection: MongoCollection, operation: MongoCursorOperation, query: _bson_ptr_mutable, fields: _bson_ptr_mutable, options: MongoCursorOptions) {
         
         switch operation {
 
@@ -34,7 +34,9 @@ public class MongoCursor {
                 options.skip.UInt32Value,
                 options.limit.UInt32Value,
                 options.batchSize.UInt32Value,
-                query, nil, nil
+                query,
+                fields,
+                nil
             )
         }
     }

--- a/SwiftMongoDBTests/SwiftMongoDBTests.swift
+++ b/SwiftMongoDBTests/SwiftMongoDBTests.swift
@@ -82,19 +82,32 @@ class SwiftMongoDBSpec: QuickSpec {
             describe("find method") {
                 // needs to query for specific id, then insert document with said id, then query again
                 it("queries for documents successfully") {
-
+                    
                     let objId = ["$oid":"55ef8ab5bb6a9b5717de15e9"]
-
+                    
                     let resultBefore = try! collection.find(["_id":objId]).count
-
+                    
                     var doc2 = document.data
                     doc2["_id"] = objId
-
+                    
                     try! collection.insert(doc2)
-
+                    
                     let resultAfter = try! collection.find(["_id":objId]).count
-
+                    
                     expect(resultAfter - resultBefore).to(equal(1))
+                }
+                
+                it("limits fields of documents successfully") {
+                    
+                    let objId = ["$oid":"55ef8ab5bb6a9b5717de15e9"]
+                    
+                    let resultAllFields = try! collection.findOne(["_id":objId])
+                    
+                    expect(resultAllFields?.data.count == document.data.count)
+                    
+                    let resultOneField = try! collection.findOne(["_id":objId], fields: ["string": true, "_id": false])
+                    
+                    expect(resultOneField?.data.count == 1)
                 }
                 
                 it("properly applies the limit flag") {
@@ -106,7 +119,6 @@ class SwiftMongoDBSpec: QuickSpec {
                     for _ in 0..<10 {
                         try! collection.insert(data)
                     }
-
                     let count = try! collection.find(limit: 3).count
 
                     expect(count).to(equal(3))


### PR DESCRIPTION
Added support for specifying which fields should be returned in find results.  I wanted this because I only want to get a few small fields from a number of large documents.
